### PR TITLE
Makes the perl 5.8.0 prerequisite required instead of recommended

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -2,6 +2,7 @@ name    = Parse-BBCode
 author  = Tina Mueller <tinita@cpan.org>
 license = Perl_5
 version = 0.15
+copyright_holder = Tina Mueller
 
 [@Basic]
 [PkgVersion]
@@ -9,10 +10,10 @@ version = 0.15
 skip = ^Email::Valid
 skip = ^URI::Find
 [Prereqs]
--relationship = recommends
+perl = 5.8.0
+[Prereqs / RuntimeRecommends]
 Email::Valid = 0
 URI::Find = 0
-perl = 5.8.0
 [MetaProvides::Package]
 [MetaResources]
 repository.web    = https://github.com/perlpunk/Parse-BBCode


### PR DESCRIPTION
- Parameter reordering in sprintf was added in 5.8. Prior versions of
  perl fail tests.
- This patch also adds the copyright_holder which appears to required by
  newer versions of Dist::Zilla
[This is my (late) contribution for the April PRC.]